### PR TITLE
[Feature] Explicitly add AWS/GCP/Azure support in `fiber` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-#from python:3.6.8-stretch
-from ubuntu:18.04
-RUN apt-get update && apt-get install -y python3-pip
-RUN apt-get update && apt-get install -y gdb python2.7-dbg netcat vim net-tools git
+FROM python:3.6.8-stretch
+RUN pip3 install fiber
 ADD . /work/
 RUN cd /work && pip3 install -e .[test]
 RUN cd /work && pip3 install -e .


### PR DESCRIPTION
Previously, only GCP is supported in `fiber` command. This PR is to add support for Kubernetes on AWS, Azure and GCP. 

Command-line usage:
```
# Explicitly specify a cloud provider
$ fiber run --aws python my.py
$ fiber run --gcp python my.py
$ fiber run --azure python my.py

# Automatically detect cloud provider (based on if any of `aws`, `gcloud` exists)
$ fiber run python my.py
```