### PR TITLE
Fix typo

### DIFF
--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -520,7 +520,7 @@ variables is:</p>
 <span class="k">def</span> <span class="nf">main</span><span class="p">():</span>
     <span class="n">fiber_config</span><span class="o">.</span><span class="n">log_level</span> <span class="o">=</span> <span class="s2">&quot;debug&quot;</span>
     <span class="n">fiber_config</span><span class="o">.</span><span class="n">log_file</span> <span class="o">=</span> <span class="s2">&quot;stdout&quot;</span>
-    <span class="n">fiber_cofnig</span><span class="o">.</span><span class="n">backend</span> <span class="o">=</span> <span class="s2">&quot;local&quot;</span>
+    <span class="n">fiber_config</span><span class="o">.</span><span class="n">backend</span> <span class="o">=</span> <span class="s2">&quot;local&quot;</span>
 </pre></div>
 
 

--- a/fiber/__init__.py
+++ b/fiber/__init__.py
@@ -33,7 +33,7 @@ if sys.platform == 'win32':
 
 init_fiber()
 
-if os.environ.get("FIBER_WORRKER", None) is None:
+if os.environ.get("FIBER_WORKER", None) is None:
     # Only initialize logger when fiber is imported in master process. Worker
     # process will get their logger initialized later.
     # A file based logger could be created, no logging lines after

--- a/fiber/popen_fiber_spawn.py
+++ b/fiber/popen_fiber_spawn.py
@@ -45,7 +45,7 @@ import sys;
 import os;
 import socket;
 import struct;
-os.environ["FIBER_WORRKER"]="1";
+os.environ["FIBER_WORKER"]="1";
 os.chdir("{cwd}");
 import fiber;
 import fiber.spawn;


### PR DESCRIPTION
Fixed typo in `docs` and environment variable name.