### PR TITLE
When pool worker exit normally, exitcode should be 0

### DIFF
--- a/fiber/process.py
+++ b/fiber/process.py
@@ -297,7 +297,7 @@ class Process(BaseProcess):
         except SystemExit as e:
             err = None
             if not e.args:
-                exitcode = 1
+                exitcode = 0
             elif isinstance(e.args[0], int):
                 exitcode = e.args[0]
             else:


### PR DESCRIPTION
When the pool workers exit, the exit code was set to 1. This PR fixes this issue.