### PR TITLE
Fix argument preparation for Pool.starmap

### DIFF
--- a/fiber/pool.py
+++ b/fiber/pool.py
@@ -1293,9 +1293,11 @@ class ZPool():
 
         seq = self._inventory.add(len(iterable))
 
+        iterable = [(item,) for item in iterable]
+
         chunks = self.__class__._chunks(iterable, chunksize)
         for batch, chunk in enumerate(chunks):
-            self._task_put((seq, batch * chunksize, func, (chunk, ), True))
+            self._task_put((seq, batch * chunksize, func, chunk, True))
 
         res = MapResult(seq, self._inventory)
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -18,6 +18,8 @@ def client():
 def f(x):
     return x * x
 
+def f2(x, y):
+    return x * y
 
 def fy(x, y=1):
     return x * x * y
@@ -137,6 +139,18 @@ class TestPool():
         assert res == [x * x for x in range(100)]
 
         async_res = pool.starmap_async(f, [(x,) for x in range(100)], 1)
+        res = async_res.get()
+        assert res == [x * x for x in range(100)]
+
+        pool.terminate()
+        pool.join()
+
+    def test_pool_starmap2(self):
+        pool = Pool(4)
+        res = pool.starmap(f2, [(x, x) for x in range(100)], 10)
+        assert res == [x * x for x in range(100)]
+
+        async_res = pool.starmap_async(f, [(x,) for x in range(100)], 10)
         res = async_res.get()
         assert res == [x * x for x in range(100)]
 


### PR DESCRIPTION
Both Pool.startmap and Pool.apply_async set `starmap=True` when creating
tasks. Previously Pool.starmap didn't have correct argument list. The
correct format should be:

    [(args, kwargs), ...] (used by Pool.apply_async) or
    [(args,), ...] (used by Pool.starmap)