### PR TITLE
Allow docker registry in generic platform

### DIFF
--- a/fiber/cli.py
+++ b/fiber/cli.py
@@ -249,7 +249,12 @@ class DockerImageBuilder:
         return self.full_image_name
 
     def tag(self):
-        self.full_image_name = self.image_name
+        if self.registry != "":
+            self.full_image_name = "{}/{}".format(
+                self.registry, self.image_name
+            )
+
+        self.docker_tag(self.image_name, self.full_image_name)
 
     def push(self):
         sp.check_call(


### PR DESCRIPTION
This extends #39 to allow docker registry to be specified in `generic` platform.